### PR TITLE
refactor Compressed messages

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,11 +81,10 @@ func main() {
 		Options: &protocol.MessageOptions{},
 	}
 
-	packedFwd := protocol.NewPackedForwardMessage(tagVar+".packed", fwd.Entries,
-		&protocol.MessageOptions{})
+	packedFwd := protocol.NewPackedForwardMessage(tagVar+".packed", fwd.Entries)
 
-	compressed := protocol.NewCompressedPackedForwardMessage(tagVar+".compressed",
-		fwd.Entries, &protocol.MessageOptions{})
+	compressed, _ := protocol.NewCompressedPackedForwardMessage(tagVar+".compressed",
+		fwd.Entries)
 
 	c.SendMessage(&msg)
 	c.SendMessage(&mne)

--- a/fluent/protocol/packed_forward_message_test.go
+++ b/fluent/protocol/packed_forward_message_test.go
@@ -121,3 +121,41 @@ func BenchmarkDecodePackedForwardMessage(b *testing.B) {
 		}
 	}
 }
+
+func TestEncodeDecodeCompressedPackedForwardMessage(t *testing.T) {
+	bits := make([]byte, 1028)
+	v, err := NewCompressedPackedForwardMessageFromBytes("foo", bits)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var buf bytes.Buffer
+	msgp.Encode(&buf, v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodePackedForwardMessage Msgsize() is inaccurate")
+	}
+
+	vn := PackedForwardMessage{}
+	err = msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkNCFMFB(b *testing.B) {
+	bits := make([]byte, 1028)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewCompressedPackedForwardMessageFromBytes("foo", bits)
+	}
+}

--- a/fluent/protocol/transport_test.go
+++ b/fluent/protocol/transport_test.go
@@ -129,7 +129,6 @@ var _ = Describe("Transport", func() {
 		var (
 			tag     string
 			entries EntryList
-			opts    *MessageOptions
 		)
 
 		BeforeEach(func() {
@@ -150,18 +149,17 @@ var _ = Describe("Transport", func() {
 					},
 				},
 			}
-			opts = &MessageOptions{}
 		})
 
 		It("Returns a PackedForwardMessage", func() {
-			msg := NewPackedForwardMessage(tag, entries, opts)
+			msg := NewPackedForwardMessage(tag, entries)
 			Expect(msg).NotTo(BeNil())
 		})
 
 		It("Includes the number of events as the `size` option", func() {
-			msg := NewPackedForwardMessage(tag, entries, opts)
-			size := msg.Options.Size
-			Expect(size).To(Equal(len(entries)))
+			msg := NewPackedForwardMessage(tag, entries)
+			Expect(msg.Options.Size).To(Equal(len(entries)))
+			Expect(msg.Options.Compressed).To(BeEmpty())
 		})
 
 		XIt("Correctly encodes the entries into a bytestream", func() {
@@ -169,7 +167,7 @@ var _ = Describe("Transport", func() {
 			// single array of EntryExt objects, but it's a stream of encoded
 			// EntryExt objects (NOT an array), and the test does not match
 			// up to that.
-			msg := NewPackedForwardMessage(tag, entries, opts)
+			msg := NewPackedForwardMessage(tag, entries)
 			elist := make(EntryList, 2)
 			_, err := elist.UnmarshalMsg(msg.EventStream)
 			Expect(err).NotTo(HaveOccurred())
@@ -182,7 +180,6 @@ var _ = Describe("Transport", func() {
 		var (
 			tag     string
 			entries []EntryExt
-			opts    *MessageOptions
 		)
 
 		BeforeEach(func() {
@@ -203,12 +200,14 @@ var _ = Describe("Transport", func() {
 					},
 				},
 			}
-			opts = &MessageOptions{}
 		})
 
 		It("Returns a message with a gzip-compressed event stream", func() {
-			msg := NewCompressedPackedForwardMessage(tag, entries, opts)
+			msg, err := NewCompressedPackedForwardMessage(tag, entries)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(msg).NotTo(BeNil())
+			Expect(msg.Options.Size).To(Equal(len(entries)))
+			Expect(msg.Options.Compressed).To(Equal("gzip"))
 		})
 	})
 })


### PR DESCRIPTION
These changes allow creating CompressedPackedForward messages from byte arrays

I also removed the MessageOptions parameter from the message constructors. We were passing them as pointers and then making changes to them. That could cause problems for the user if they're trying to reuse the same object and aren't expecting it to change. Also, I don't think there are many cases where the user will want to touch the options.