### PR TITLE
Make options size a pointer

### DIFF
--- a/fluent/protocol/transport.go
+++ b/fluent/protocol/transport.go
@@ -143,7 +143,7 @@ type Entry struct {
 }
 
 type MessageOptions struct {
-	Size       int    `msg:"size"`
+	Size       *int   `msg:"size,omitempty"`
 	Chunk      string `msg:"chunk,omitempty"`
 	Compressed string `msg:"compressed,omitempty"`
 }

--- a/fluent/protocol/transport_test.go
+++ b/fluent/protocol/transport_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Transport", func() {
 
 		It("Includes the number of events as the `size` option", func() {
 			msg := NewPackedForwardMessage(tag, entries)
-			Expect(msg.Options.Size).To(Equal(len(entries)))
+			Expect(*msg.Options.Size).To(Equal(len(entries)))
 			Expect(msg.Options.Compressed).To(BeEmpty())
 		})
 
@@ -206,7 +206,7 @@ var _ = Describe("Transport", func() {
 			msg, err := NewCompressedPackedForwardMessage(tag, entries)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(msg).NotTo(BeNil())
-			Expect(msg.Options.Size).To(Equal(len(entries)))
+			Expect(*msg.Options.Size).To(Equal(len(entries)))
 			Expect(msg.Options.Compressed).To(Equal("gzip"))
 		})
 	})


### PR DESCRIPTION
I realized there's a different meaning between omitting the `size` option and setting it to `0`. In one case you're saying "I'm not telling you what the length is". In the other case, you could be saying "the length of the entries is 0". By making this a pointer, we can disambiguate what it means when `size` isn't set.