### PR TITLE
Graceful close of websocket connection

### DIFF
--- a/cmd/ws/listener.go
+++ b/cmd/ws/listener.go
@@ -55,7 +55,6 @@ func (s *Listener) Connect(w http.ResponseWriter, r *http.Request) {
 			!websocket.IsCloseError(err, websocket.CloseNormalClosure) {
 			log.Println("server listen error:", err)
 		}
-
 	}
 }
 

--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -26,7 +26,7 @@ func init() {
 //nolint
 func listen() *Listener {
 
-	log.Println("Starting server on port 808")
+	log.Println("Starting server on port 8083")
 
 	s := &http.Server{Addr: ":8083"}
 	wo := ws.ConnectionOptions{

--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -34,11 +34,7 @@ func listen() *Listener {
 			msg := protocol.Message{}
 			msg.UnmarshalMsg(p)
 
-			log.Println("server got a message", msg)
-
-			if err != nil {
-				log.Println(conn.Close())
-			}
+			log.Println("server got a message", msg, err)
 
 			return err
 		},

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -269,7 +269,7 @@ func (wsc *connection) Listen() error {
 
 	wsc.setConnState(ConnStateListening)
 
-	nextMsg := make(chan *connMsg)
+	nextMsg := make(chan connMsg)
 
 	go func() {
 		defer func() {
@@ -279,7 +279,7 @@ func (wsc *connection) Listen() error {
 		}()
 
 		for {
-			msg := &connMsg{}
+			msg := connMsg{} // use object pool?
 			msg.mt, msg.message, msg.err = wsc.Conn.ReadMessage()
 
 			log.Printf("%s next message: %+v", wsc.id, msg)

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -245,6 +245,7 @@ func (wsc *connection) Listen() error {
 
 	go func() {
 		defer func() {
+			close(nextMsg)
 			wsc.unsetConnState(ConnStateListening)
 			wsc.closedSig <- struct{}{}
 		}()
@@ -271,7 +272,6 @@ func (wsc *connection) Listen() error {
 			}
 		}
 
-		close(nextMsg)
 	}()
 
 	var err error

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -67,7 +67,7 @@ type connection struct {
 	id            string
 }
 
-func NewConnection(conn ext.Conn, opts *ConnectionOptions) (Connection, error) {
+func NewConnection(conn ext.Conn, opts ConnectionOptions) (Connection, error) {
 	wsc := &connection{
 		Conn:      conn,
 		closedSig: make(chan struct{}),

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -239,6 +239,7 @@ func (wsc *connection) Listen() error {
 	wsc.listenLock.Lock()
 
 	if wsc.hasConnState(ConnStateListening) {
+		wsc.listenLock.Unlock()
 		return errors.New("already listening on this connection")
 	}
 

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -311,9 +311,8 @@ func (wsc *connection) Listen() error {
 
 		if rerr := wsc.readHandler(wsc, msg.mt, msg.message, msg.err); rerr != nil {
 			// enqueue error only if it is something other than a normal close
-			log.Printf("%s readhandler err: %+v", wsc.id, msg.err)
-
-			if websocket.IsUnexpectedCloseError(rerr, websocket.CloseNormalClosure) {
+			if !websocket.IsCloseError(rerr, websocket.CloseNormalClosure) {
+				log.Printf("%s readhandler err: %+v", wsc.id, msg.err)
 				err = rerr
 			}
 		}

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -212,7 +212,7 @@ func (wsc *connection) CloseWithMsg(closeCode int, msg string) error {
 	}
 
 	// spec says that only server should close the network connection,
-	// but general consensus is that it doesn't matter
+	// but consensus is that it doesn't matter
 	return wsc.Conn.Close()
 }
 

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -278,8 +278,9 @@ func (wsc *connection) Listen() error {
 			log.Println(wsc.id, "exit ReadMessage loop")
 		}()
 
+		msg := connMsg{}
+
 		for {
-			msg := connMsg{} // use object pool?
 			msg.mt, msg.message, msg.err = wsc.Conn.ReadMessage()
 
 			log.Printf("%s next message: %+v", wsc.id, msg)

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -185,8 +185,6 @@ func (wsc *connection) CloseWithMsg(closeCode int, msg string) error {
 
 	wsc.setConnState(ConnStateClosed)
 
-	// spec says that only server should close the network connection,
-	// but consensus is that it doesn't matter
 	if cerr := wsc.Conn.Close(); cerr != nil {
 		err = cerr
 	}

--- a/fluent/client/ws/connection_test.go
+++ b/fluent/client/ws/connection_test.go
@@ -175,6 +175,7 @@ var _ = Describe("Connection", func() {
 		When("already listening", func() {
 			It("errors", func() {
 				Expect(connection.Listen().Error()).To(MatchRegexp("already listening on this connection"))
+				Expect(connection.Listen().Error()).To(MatchRegexp("already listening on this connection"))
 			})
 		})
 

--- a/fluent/client/ws/connection_test.go
+++ b/fluent/client/ws/connection_test.go
@@ -35,13 +35,13 @@ var _ = Describe("Connection", func() {
 		checkSvrClose               bool
 		connection, svrConnection   ws.Connection
 		svr                         *httptest.Server
-		opts                        *ws.ConnectionOptions
+		opts                        ws.ConnectionOptions
 		svrRcvdMsgs, clientRcvdMsgs chan message
 		listenErrs                  chan error
 	)
 
-	var makeOpts = func(msgChan chan message, name string) *ws.ConnectionOptions {
-		return &ws.ConnectionOptions{
+	var makeOpts = func(msgChan chan message, name string) ws.ConnectionOptions {
+		return ws.ConnectionOptions{
 			CloseDeadline: 500 * time.Millisecond,
 			ReadHandler: func(conn ws.Connection, msgType int, p []byte, err error) error {
 				msg := message{

--- a/fluent/client/ws/connection_test.go
+++ b/fluent/client/ws/connection_test.go
@@ -55,7 +55,6 @@ var _ = Describe("Connection", func() {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer GinkgoRecover()
 			svrOpts := makeOpts(svrRcvdMsgs, "server")
-			svrOpts.ID = "server"
 
 			var upgrader websocket.Upgrader
 			wc, _ := upgrader.Upgrade(w, r, nil)
@@ -82,7 +81,6 @@ var _ = Describe("Connection", func() {
 		checkClose = true
 		clientRcvdMsgs = make(chan message, 1)
 		opts = makeOpts(clientRcvdMsgs, "client")
-		opts.ID = "client"
 
 		u := "ws" + strings.TrimPrefix(svr.URL, "http")
 		conn, _, err := websocket.DefaultDialer.Dial(u, nil)

--- a/fluent/client/ws/connection_test.go
+++ b/fluent/client/ws/connection_test.go
@@ -3,6 +3,7 @@ package ws_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -24,36 +25,42 @@ type message struct {
 }
 
 var _ = Describe("Connection", func() {
-	var (
-		fakeConn                    *extfakes.FakeConn
-		opts                        ws.ConnectionOptions
-		svrReadMsgs, clientReadMsgs chan message
-		rhCallCt, rcvdMsgCt         int32
-		onFail                      func(err error)
-		echo                        func(w http.ResponseWriter, r *http.Request)
-	)
 
-	var upgrader = websocket.Upgrader{}
+	// Describe("NewConnection", func() {
+	// 	It("works", func() {
+	// 		c, err := ws.NewConnection(fakeConn, ws.ConnectionOptions{})
+	// 		Expect(err).ToNot(HaveOccurred())
+	// 		Expect(c).ToNot(BeNil())
+	// 		// TODO: test options are set correctly
+	// 	})
+	// })
 
-	BeforeEach(func() {
-		rhCallCt = 0
-		rcvdMsgCt = 0
-		svrReadMsgs = make(chan message)
-		clientReadMsgs = make(chan message)
-		fakeConn = &extfakes.FakeConn{}
+	Describe("Connection", func() {
+		var (
+			connection, svrConnection   ws.Connection
+			doClose                     bool
+			svr                         *httptest.Server
+			fakeConn                    *extfakes.FakeConn
+			opts                        *ws.ConnectionOptions
+			svrRcvdMsgs, clientRcvdMsgs chan message
+			rhCallCt, rcvdMsgCt         *int32
+			onListenFail                func(err error)
+			listenErrCt                 int
+		)
 
-		echo = func(w http.ResponseWriter, r *http.Request) {
-			xopts := ws.ConnectionOptions{
-				CloseDeadline: 100 * time.Millisecond,
+		var makeOpts = func(msgChan chan message, counter *int32) *ws.ConnectionOptions {
+			return &ws.ConnectionOptions{
+				CloseDeadline: 500 * time.Millisecond,
 				ReadHandler: func(conn ws.Connection, msgType int, p []byte, err error) error {
-					atomic.AddInt32(&rcvdMsgCt, 1)
+
+					atomic.AddInt32(counter, 1)
 					msg := message{
 						mt:  msgType,
 						msg: p,
 						err: err,
 					}
 
-					svrReadMsgs <- msg
+					msgChan <- msg
 
 					if err != nil {
 						conn.Close()
@@ -62,88 +69,62 @@ var _ = Describe("Connection", func() {
 					return err
 				},
 			}
-
-			wc, _ := upgrader.Upgrade(w, r, nil)
-			c, err := ws.NewConnection(wc, xopts)
-
-			if err != nil {
-				return
-			}
-
-			defer c.Close()
-			c.Listen()
 		}
-
-		opts = ws.ConnectionOptions{
-			CloseDeadline: 100 * time.Millisecond,
-			ReadHandler: func(conn ws.Connection, msgType int, p []byte, err error) error {
-				atomic.AddInt32(&rhCallCt, 1)
-				msg := message{
-					mt:  msgType,
-					msg: p,
-					err: err,
-				}
-				clientReadMsgs <- msg
-				if err != nil {
-					conn.Close()
-				}
-				return err
-			},
-		}
-
-		onFail = nil
-
-	})
-
-	AfterEach(func() {
-		close(svrReadMsgs)
-		close(clientReadMsgs)
-	})
-
-	Describe("NewConnection", func() {
-		It("works", func() {
-			c, err := ws.NewConnection(fakeConn, ws.ConnectionOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(c).ToNot(BeNil())
-			// TODO: test options are set correctly
-		})
-	})
-
-	Describe("Connection", func() {
-		var (
-			connection ws.Connection
-			doClose    bool
-			svr        *httptest.Server
-		)
 
 		BeforeEach(func() {
+			rh := int32(0)
+			rc := rh
 			doClose = true
+			rhCallCt = &rh
+			rcvdMsgCt = &rc
+			svrRcvdMsgs = make(chan message)
 
-			svr = httptest.NewServer(http.HandlerFunc(echo))
+			svr = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				svrOpts := makeOpts(svrRcvdMsgs, rcvdMsgCt)
 
+				var upgrader websocket.Upgrader
+				wc, _ := upgrader.Upgrade(w, r, nil)
+				var err error
+				svrConnection, err = ws.NewConnection(wc, svrOpts)
+
+				if err != nil {
+					return
+				}
+
+				defer svrConnection.Close()
+				Expect(svrConnection.Listen()).ToNot(HaveOccurred())
+			}))
+
+			clientRcvdMsgs = make(chan message, 1)
+			fakeConn = &extfakes.FakeConn{}
+			listenErrCt = 0
+			opts = makeOpts(clientRcvdMsgs, rhCallCt)
+			onListenFail = nil
+
+		})
+
+		JustBeforeEach(func() {
 			u := "ws" + strings.TrimPrefix(svr.URL, "http")
-
-			// Connect to the server
 			conn, _, err := websocket.DefaultDialer.Dial(u, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			connection, err = ws.NewConnection(conn, opts)
 			Expect(err).ToNot(HaveOccurred())
-		})
-
-		JustBeforeEach(func() {
 			startSig := make(chan struct{}, 1)
 
 			go func() {
 				defer GinkgoRecover()
 				startSig <- struct{}{}
+				fmt.Println("here")
 				if err := connection.Listen(); err != nil {
-					if onFail == nil {
-						defer GinkgoRecover()
+					fmt.Println("chere")
+					if onListenFail == nil {
 						Fail(err.Error())
 					}
-					onFail(err)
+					onListenFail(err)
 				}
+				fmt.Println("there")
 			}()
 
 			// wait for Listen loop to start
@@ -157,22 +138,24 @@ var _ = Describe("Connection", func() {
 				Eventually(connection.Closed).Should(BeTrue())
 			}
 			svr.Close()
+			close(svrRcvdMsgs)
+			close(clientRcvdMsgs)
 		})
 
 		Describe("WriteMessage", func() {
 			When("everything is copacetic", func() {
-				FIt("writes messages to the connection", func() {
+				It("writes messages to the connection", func() {
 					err := connection.WriteMessage(1, []byte("oi"))
 					Expect(err).ToNot(HaveOccurred())
 					err = connection.WriteMessage(1, []byte("koi"))
 					Expect(err).ToNot(HaveOccurred())
 
-					x := <-svrReadMsgs
-					Expect(x.msg).To(Equal([]byte("oi")))
-					x = <-svrReadMsgs
-					Expect(x.msg).To(Equal([]byte("koi")))
+					m := <-svrRcvdMsgs
+					Expect(m.msg).To(Equal([]byte("oi")))
+					m = <-svrRcvdMsgs
+					Expect(m.msg).To(Equal([]byte("koi")))
 
-					Consistently(svrReadMsgs).ShouldNot(Receive())
+					Consistently(svrRcvdMsgs).ShouldNot(Receive())
 				})
 			})
 
@@ -190,25 +173,25 @@ var _ = Describe("Connection", func() {
 
 		Describe("ReadMessage", func() {
 			When("everything is copacetic", func() {
-				It("reads a message from the connection and calls the read handler", func() {
-					//svrReadMsgs <- message{1, []byte("oi"), nil}
-					var gt int32
-					Expect(rcvdMsgCt).To(Equal(gt))
+				FIt("reads a message from the connection and calls the read handler", func() {
+					Expect(len(svrRcvdMsgs)).To(Equal(0))
+
 					err := connection.WriteMessage(1, []byte("oi"))
 					Expect(err).ToNot(HaveOccurred())
-					Eventually(func() int32 { return rcvdMsgCt }).Should(BeNumerically(">", gt))
-					//Eventually(func() int32 { return rmCallCt }).Should(BeNumerically(">", gt))
+
+					m := <-svrRcvdMsgs
+					Expect(m.err).ToNot(HaveOccurred())
+
+					Consistently(svrRcvdMsgs).ShouldNot(Receive())
 				})
 			})
 
 			When("an error occurs", func() {
-				var callCt int
-				BeforeEach(func() {
-					callCt = 0
-					fakeConn.ReadMessageReturns(1, nil, &websocket.CloseError{})
-					onFail = func(e error) {
-						defer GinkgoRecover()
-						callCt++
+				// var listenErrCt int
+				JustBeforeEach(func() {
+					doClose = false
+					onListenFail = func(e error) {
+						listenErrCt++
 						if e == nil {
 							Fail("the BOOMing, where is it?")
 						}
@@ -216,8 +199,21 @@ var _ = Describe("Connection", func() {
 				})
 
 				It("enqueues the error", func() {
-					Eventually(func() int { return int(rhCallCt) }).Should(BeNumerically(">=", 1))
-					Eventually(func() int { return callCt }).Should(BeNumerically("==", 1))
+					// u := "ws" + strings.TrimPrefix(svr.URL, "http")
+					// conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+					// Expect(err).ToNot(HaveOccurred())
+					// connection, err = ws.NewConnection(conn, opts)
+					// Expect(err).ToNot(HaveOccurred())
+					//	Expect(connection.UnderlyingConn().Close()).ToNot(HaveOccurred())
+					//svrConnection.WriteMessage(websocket.TextMessage, []byte("oi"))
+
+					err := svrConnection.CloseWithMsg(websocket.ClosePolicyViolation, "meh")
+					Expect(err).ToNot(HaveOccurred())
+					// fmt.Println(<-svrRcvdMsgs)
+					// fmt.Println(<-svrRcvdMsgs)
+					//	Eventually(svrRcvdMsgs).Should(Receive())
+					//Eventually(func() int { return int(rhCallCt) }).Should(BeNumerically("==", 1))
+					Eventually(func() int { return int(*rhCallCt) }).Should(BeNumerically("==", 1))
 				})
 
 				When("the error is a normal close", func() {
@@ -226,8 +222,8 @@ var _ = Describe("Connection", func() {
 					})
 
 					It("does not enqueue the error", func() {
-						Eventually(func() int { return int(rhCallCt) }).Should(BeNumerically(">=", 1))
-						Consistently(func() int { return callCt }).Should(BeNumerically("==", 0))
+						Eventually(func() int { return int(*rhCallCt) }).Should(BeNumerically(">=", 1))
+						Consistently(func() int { return listenErrCt }).Should(BeNumerically("==", 0))
 					})
 				})
 			})

--- a/fluent/client/ws/connection_test.go
+++ b/fluent/client/ws/connection_test.go
@@ -2,17 +2,13 @@ package ws_test
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
-	"net"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/IBM/fluent-forward-go/fluent/client/ws"
-	"github.com/IBM/fluent-forward-go/fluent/client/ws/ext/extfakes"
 	"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,245 +31,213 @@ var _ = Describe("Connection", func() {
 	// 	})
 	// })
 
-	Describe("Connection", func() {
-		var (
-			connection, svrConnection   ws.Connection
-			doClose                     bool
-			svr                         *httptest.Server
-			fakeConn                    *extfakes.FakeConn
-			opts                        *ws.ConnectionOptions
-			svrRcvdMsgs, clientRcvdMsgs chan message
-			rhCallCt, rcvdMsgCt         *int32
-			onListenFail                func(err error)
-			listenErrCt                 int
-		)
+	var (
+		checkSvrClose               bool
+		connection, svrConnection   ws.Connection
+		svr                         *httptest.Server
+		opts                        *ws.ConnectionOptions
+		svrRcvdMsgs, clientRcvdMsgs chan message
+		listenErrs                  chan error
+	)
 
-		var makeOpts = func(msgChan chan message, counter *int32) *ws.ConnectionOptions {
-			return &ws.ConnectionOptions{
-				CloseDeadline: 500 * time.Millisecond,
-				ReadHandler: func(conn ws.Connection, msgType int, p []byte, err error) error {
-
-					atomic.AddInt32(counter, 1)
-					msg := message{
-						mt:  msgType,
-						msg: p,
-						err: err,
-					}
-
-					msgChan <- msg
-
-					if err != nil {
-						conn.Close()
-					}
-
-					return err
-				},
-			}
-		}
-
-		BeforeEach(func() {
-			rh := int32(0)
-			rc := rh
-			doClose = true
-			rhCallCt = &rh
-			rcvdMsgCt = &rc
-			svrRcvdMsgs = make(chan message)
-
-			svr = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				defer GinkgoRecover()
-				svrOpts := makeOpts(svrRcvdMsgs, rcvdMsgCt)
-
-				var upgrader websocket.Upgrader
-				wc, _ := upgrader.Upgrade(w, r, nil)
-				var err error
-				svrConnection, err = ws.NewConnection(wc, svrOpts)
+	var makeOpts = func(msgChan chan message, name string) *ws.ConnectionOptions {
+		return &ws.ConnectionOptions{
+			CloseDeadline: 500 * time.Millisecond,
+			ReadHandler: func(conn ws.Connection, msgType int, p []byte, err error) error {
+				msg := message{
+					mt:  msgType,
+					msg: p,
+					err: err,
+				}
+				msgChan <- msg
 
 				if err != nil {
-					return
+					log.Println(name, "ReadHandler received error:", err)
 				}
 
-				defer svrConnection.Close()
-				Expect(svrConnection.Listen()).ToNot(HaveOccurred())
-			}))
+				return err
+			},
+		}
+	}
 
-			clientRcvdMsgs = make(chan message, 1)
-			fakeConn = &extfakes.FakeConn{}
-			listenErrCt = 0
-			opts = makeOpts(clientRcvdMsgs, rhCallCt)
-			onListenFail = nil
+	newHandler := func(svrRcvdMsgs chan message) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+			svrOpts := makeOpts(svrRcvdMsgs, "server")
+			svrOpts.ID = "server"
 
+			var upgrader websocket.Upgrader
+			wc, _ := upgrader.Upgrade(w, r, nil)
+
+			var err error
+			svrConnection, err = ws.NewConnection(wc, svrOpts)
+			if err != nil {
+				return
+			}
+
+			Expect(svrConnection.Listen()).ToNot(HaveOccurred())
+			log.Println("exit server handler")
+		})
+	}
+
+	BeforeEach(func() {
+		checkSvrClose = true
+		svrRcvdMsgs = make(chan message)
+		svr = httptest.NewServer(newHandler(svrRcvdMsgs))
+
+		clientRcvdMsgs = make(chan message, 1)
+		opts = makeOpts(clientRcvdMsgs, "client")
+		opts.ID = "client"
+
+		u := "ws" + strings.TrimPrefix(svr.URL, "http")
+		conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		connection, err = ws.NewConnection(conn, opts)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	JustBeforeEach(func() {
+		listenErrs = make(chan error)
+
+		go func() {
+			defer GinkgoRecover()
+			if err := connection.Listen(); err != nil {
+				listenErrs <- err
+			}
+		}()
+
+		// wait for Listen loop to start
+		time.Sleep(10 * time.Millisecond)
+		Expect(connection.Closed()).To(BeFalse())
+	})
+
+	AfterEach(func() {
+		if !connection.Closed() {
+			Expect(connection.Close()).ToNot(HaveOccurred())
+			Eventually(connection.Closed).Should(BeTrue())
+		}
+
+		if !svrConnection.Closed() {
+			err := svrConnection.Close()
+			if checkSvrClose {
+				Expect(err).ToNot(HaveOccurred())
+			}
+			Eventually(svrConnection.Closed).Should(BeTrue())
+		}
+
+		svr.Close()
+	})
+
+	Describe("WriteMessage", func() {
+		When("everything is copacetic", func() {
+			It("writes messages to the connection", func() {
+				err := connection.WriteMessage(1, []byte("oi"))
+				Expect(err).ToNot(HaveOccurred())
+				err = connection.WriteMessage(1, []byte("koi"))
+				Expect(err).ToNot(HaveOccurred())
+
+				m := <-svrRcvdMsgs
+				Expect(m.msg).To(Equal([]byte("oi")))
+				m = <-svrRcvdMsgs
+				Expect(m.msg).To(Equal([]byte("koi")))
+
+				Consistently(svrRcvdMsgs).ShouldNot(Receive())
+			})
 		})
 
+		When("an error occurs", func() {
+			It("returns an error", func() {
+				Expect(connection.Close()).ToNot(HaveOccurred())
+				Expect(connection.WriteMessage(1, nil).Error()).To(MatchRegexp("close sent"))
+			})
+		})
+	})
+
+	Describe("Listen", func() {
+		When("everything is copacetic", func() {
+			It("reads a message from the connection and calls the read handler", func() {
+				Expect(len(svrRcvdMsgs)).To(Equal(0))
+
+				err := connection.WriteMessage(1, []byte("oi"))
+				Expect(err).ToNot(HaveOccurred())
+
+				m := <-svrRcvdMsgs
+				Expect(m.err).ToNot(HaveOccurred())
+				Expect(bytes.Equal(m.msg, []byte("oi"))).To(BeTrue())
+
+				Consistently(svrRcvdMsgs).ShouldNot(Receive())
+			})
+		})
+
+		When("already listening", func() {
+			It("errors", func() {
+				Expect(connection.Listen().Error()).To(MatchRegexp("already listening on this connection"))
+			})
+		})
+
+		When("an error occurs", func() {
+			It("enqueues the error", func() {
+				err := svrConnection.CloseWithMsg(websocket.ClosePolicyViolation, "meh")
+				Expect(err).ToNot(HaveOccurred())
+				err = <-listenErrs
+				Expect(err.Error()).To(MatchRegexp("meh"))
+			}, 5)
+
+			When("the error is a normal close", func() {
+				It("does not enqueue the error", func() {
+					Expect(svrConnection.Close()).ToNot(HaveOccurred())
+					Consistently(listenErrs).ShouldNot(Receive())
+				})
+			})
+		})
+	})
+
+	Describe("CloseWithMsg", func() {
+		When("everything is copacetic", func() {
+			It("sends a signal", func() {
+				Expect(connection.CloseWithMsg(1000, "oi")).ToNot(HaveOccurred())
+				Expect(connection.Closed()).To(BeTrue())
+
+				closeMsg := <-svrRcvdMsgs
+				Expect(closeMsg.err.Error()).To(MatchRegexp("oi"))
+			})
+		})
+	})
+
+	Describe("Close and Closed", func() {
 		JustBeforeEach(func() {
-			u := "ws" + strings.TrimPrefix(svr.URL, "http")
-			conn, _, err := websocket.DefaultDialer.Dial(u, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			connection, err = ws.NewConnection(conn, opts)
-			Expect(err).ToNot(HaveOccurred())
-			startSig := make(chan struct{}, 1)
-
-			go func() {
-				defer GinkgoRecover()
-				startSig <- struct{}{}
-				fmt.Println("here")
-				if err := connection.Listen(); err != nil {
-					fmt.Println("chere")
-					if onListenFail == nil {
-						Fail(err.Error())
-					}
-					onListenFail(err)
-				}
-				fmt.Println("there")
-			}()
-
-			// wait for Listen loop to start
-			<-startSig
-			time.Sleep(time.Millisecond)
+			Expect(connection.Closed()).To(BeFalse())
 		})
 
 		AfterEach(func() {
-			if doClose {
+			Expect(connection.Closed()).To(BeTrue())
+		})
+
+		When("everything is copacetic", func() {
+			It("signals close", func() {
 				Expect(connection.Close()).ToNot(HaveOccurred())
-				Eventually(connection.Closed).Should(BeTrue())
-			}
-			svr.Close()
-			close(svrRcvdMsgs)
-			close(clientRcvdMsgs)
-		})
-
-		Describe("WriteMessage", func() {
-			When("everything is copacetic", func() {
-				It("writes messages to the connection", func() {
-					err := connection.WriteMessage(1, []byte("oi"))
-					Expect(err).ToNot(HaveOccurred())
-					err = connection.WriteMessage(1, []byte("koi"))
-					Expect(err).ToNot(HaveOccurred())
-
-					m := <-svrRcvdMsgs
-					Expect(m.msg).To(Equal([]byte("oi")))
-					m = <-svrRcvdMsgs
-					Expect(m.msg).To(Equal([]byte("koi")))
-
-					Consistently(svrRcvdMsgs).ShouldNot(Receive())
-				})
-			})
-
-			When("an error occurs", func() {
-				BeforeEach(func() {
-					doClose = false
-					connection.Close()
-				})
-
-				It("returns an error", func() {
-					Expect(connection.WriteMessage(1, []byte("oi"))).To(MatchError(net.ErrClosed))
-				})
+				closeMsg := <-svrRcvdMsgs
+				Expect(closeMsg.err.Error()).To(MatchRegexp("closing connection"))
 			})
 		})
 
-		Describe("ReadMessage", func() {
-			When("everything is copacetic", func() {
-				FIt("reads a message from the connection and calls the read handler", func() {
-					Expect(len(svrRcvdMsgs)).To(Equal(0))
-
-					err := connection.WriteMessage(1, []byte("oi"))
-					Expect(err).ToNot(HaveOccurred())
-
-					m := <-svrRcvdMsgs
-					Expect(m.err).ToNot(HaveOccurred())
-
-					Consistently(svrRcvdMsgs).ShouldNot(Receive())
-				})
-			})
-
-			When("an error occurs", func() {
-				// var listenErrCt int
-				JustBeforeEach(func() {
-					doClose = false
-					onListenFail = func(e error) {
-						listenErrCt++
-						if e == nil {
-							Fail("the BOOMing, where is it?")
-						}
-					}
-				})
-
-				It("enqueues the error", func() {
-					// u := "ws" + strings.TrimPrefix(svr.URL, "http")
-					// conn, _, err := websocket.DefaultDialer.Dial(u, nil)
-					// Expect(err).ToNot(HaveOccurred())
-					// connection, err = ws.NewConnection(conn, opts)
-					// Expect(err).ToNot(HaveOccurred())
-					//	Expect(connection.UnderlyingConn().Close()).ToNot(HaveOccurred())
-					//svrConnection.WriteMessage(websocket.TextMessage, []byte("oi"))
-
-					err := svrConnection.CloseWithMsg(websocket.ClosePolicyViolation, "meh")
-					Expect(err).ToNot(HaveOccurred())
-					// fmt.Println(<-svrRcvdMsgs)
-					// fmt.Println(<-svrRcvdMsgs)
-					//	Eventually(svrRcvdMsgs).Should(Receive())
-					//Eventually(func() int { return int(rhCallCt) }).Should(BeNumerically("==", 1))
-					Eventually(func() int { return int(*rhCallCt) }).Should(BeNumerically("==", 1))
-				})
-
-				When("the error is a normal close", func() {
-					BeforeEach(func() {
-						fakeConn.ReadMessageReturns(1, nil, &websocket.CloseError{Code: websocket.CloseNormalClosure})
-					})
-
-					It("does not enqueue the error", func() {
-						Eventually(func() int { return int(*rhCallCt) }).Should(BeNumerically(">=", 1))
-						Consistently(func() int { return listenErrCt }).Should(BeNumerically("==", 0))
-					})
-				})
+		When("called multiple times", func() {
+			It("errors", func() {
+				Expect(connection.Close()).ToNot(HaveOccurred())
+				Expect(connection.Close().Error()).To(MatchRegexp("multiple close calls"))
 			})
 		})
 
-		Describe("CloseWithMsg", func() {
-			When("everything is copacetic", func() {
-				It("sends a signal", func() {
-					Expect(connection.CloseWithMsg(1, "a")).ToNot(HaveOccurred())
-					a, b := fakeConn.WriteMessageArgsForCall(0)
-					Expect(a).To(Equal(8))
-					msg := websocket.FormatCloseMessage(1, "a")
-					Expect(bytes.Equal(b, msg)).To(BeTrue())
-				})
-			})
-		})
-
-		Describe("Close", func() {
+		When("the connection errors on close", func() {
 			BeforeEach(func() {
-				doClose = false
+				checkSvrClose = false
 			})
 
-			When("everything is copacetic", func() {
-				It("signals close", func() {
-					Expect(connection.Close()).ToNot(HaveOccurred())
-					a, b := fakeConn.WriteMessageArgsForCall(0)
-					Expect(a).To(Equal(8))
-					msg := websocket.FormatCloseMessage(
-						websocket.CloseNormalClosure, "so long and thanks for all the fish",
-					)
-					Expect(bytes.Equal(b, msg)).To(BeTrue())
-				})
-			})
-
-			When("called multiple times", func() {
-				It("errors", func() {
-					Expect(connection.Close()).ToNot(HaveOccurred())
-					Expect(connection.Close()).To(MatchError("multiple close calls"))
-				})
-			})
-
-			When("the connection errors on close", func() {
-				BeforeEach(func() {
-					fakeConn.WriteMessageReturns(errors.New("BOOM"))
-					fakeConn.CloseReturns(errors.New("BOOM"))
-				})
-
-				It("returns an error", func() {
-					Expect(connection.Close()).To(HaveOccurred())
-				})
+			It("returns an error", func() {
+				connection.UnderlyingConn().Close()
+				Expect(connection.Close().Error()).To(MatchRegexp("use of closed network connection"))
 			})
 		})
 	})

--- a/fluent/client/ws/connection_test.go
+++ b/fluent/client/ws/connection_test.go
@@ -187,21 +187,21 @@ var _ = Describe("Connection", func() {
 				connection.UnderlyingConn().Close()
 			})
 
-			It("enqueues a network error", func() {
+			It("returns a network error", func() {
 				err := <-listenErrs
 				Expect(err.Error()).To(MatchRegexp("use of closed network connection"))
 			})
 		})
 
 		When("a close error occurs", func() {
-			It("enqueues abnormal closures", func() {
+			It("returns abnormal closures", func() {
 				err := svrConnection.CloseWithMsg(websocket.ClosePolicyViolation, "meh")
 				Expect(err).ToNot(HaveOccurred())
 				err = <-listenErrs
 				Expect(err.Error()).To(MatchRegexp("meh"))
 			})
 
-			It("does not enqueue normal closures", func() {
+			It("does not return normal closures", func() {
 				Expect(svrConnection.Close()).ToNot(HaveOccurred())
 				Consistently(listenErrs).ShouldNot(Receive())
 			})

--- a/fluent/client/ws/wsfakes/fake_connection.go
+++ b/fluent/client/ws/wsfakes/fake_connection.go
@@ -54,6 +54,16 @@ type FakeConnection struct {
 	closedReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	ConnStateStub        func() ws.ConnState
+	connStateMutex       sync.RWMutex
+	connStateArgsForCall []struct {
+	}
+	connStateReturns struct {
+		result1 ws.ConnState
+	}
+	connStateReturnsOnCall map[int]struct {
+		result1 ws.ConnState
+	}
 	EnableWriteCompressionStub        func(bool)
 	enableWriteCompressionMutex       sync.RWMutex
 	enableWriteCompressionArgsForCall []struct {
@@ -509,6 +519,59 @@ func (fake *FakeConnection) ClosedReturnsOnCall(i int, result1 bool) {
 	}
 	fake.closedReturnsOnCall[i] = struct {
 		result1 bool
+	}{result1}
+}
+
+func (fake *FakeConnection) ConnState() ws.ConnState {
+	fake.connStateMutex.Lock()
+	ret, specificReturn := fake.connStateReturnsOnCall[len(fake.connStateArgsForCall)]
+	fake.connStateArgsForCall = append(fake.connStateArgsForCall, struct {
+	}{})
+	stub := fake.ConnStateStub
+	fakeReturns := fake.connStateReturns
+	fake.recordInvocation("ConnState", []interface{}{})
+	fake.connStateMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeConnection) ConnStateCallCount() int {
+	fake.connStateMutex.RLock()
+	defer fake.connStateMutex.RUnlock()
+	return len(fake.connStateArgsForCall)
+}
+
+func (fake *FakeConnection) ConnStateCalls(stub func() ws.ConnState) {
+	fake.connStateMutex.Lock()
+	defer fake.connStateMutex.Unlock()
+	fake.ConnStateStub = stub
+}
+
+func (fake *FakeConnection) ConnStateReturns(result1 ws.ConnState) {
+	fake.connStateMutex.Lock()
+	defer fake.connStateMutex.Unlock()
+	fake.ConnStateStub = nil
+	fake.connStateReturns = struct {
+		result1 ws.ConnState
+	}{result1}
+}
+
+func (fake *FakeConnection) ConnStateReturnsOnCall(i int, result1 ws.ConnState) {
+	fake.connStateMutex.Lock()
+	defer fake.connStateMutex.Unlock()
+	fake.ConnStateStub = nil
+	if fake.connStateReturnsOnCall == nil {
+		fake.connStateReturnsOnCall = make(map[int]struct {
+			result1 ws.ConnState
+		})
+	}
+	fake.connStateReturnsOnCall[i] = struct {
+		result1 ws.ConnState
 	}{result1}
 }
 
@@ -1769,6 +1832,8 @@ func (fake *FakeConnection) Invocations() map[string][][]interface{} {
 	defer fake.closeWithMsgMutex.RUnlock()
 	fake.closedMutex.RLock()
 	defer fake.closedMutex.RUnlock()
+	fake.connStateMutex.RLock()
+	defer fake.connStateMutex.RUnlock()
 	fake.enableWriteCompressionMutex.RLock()
 	defer fake.enableWriteCompressionMutex.RUnlock()
 	fake.listenMutex.RLock()

--- a/fluent/client/ws_client.go
+++ b/fluent/client/ws_client.go
@@ -163,7 +163,7 @@ func (c *WSClient) Connect() error {
 
 // Disconnect ends the current Session and terminates its websocket connection.
 func (c *WSClient) Disconnect() (err error) {
-	if c.Session != nil {
+	if c.Session != nil && !c.Session.Connection.Closed() {
 		err = c.Session.Connection.Close()
 	}
 

--- a/fluent/client/ws_client.go
+++ b/fluent/client/ws_client.go
@@ -140,7 +140,7 @@ func (c *WSClient) Connect() error {
 		return err
 	}
 
-	connection, err := ws.NewConnection(conn, c.ConnectionOptions)
+	connection, err := ws.NewConnection(conn, &c.ConnectionOptions)
 	if err != nil {
 		return err
 	}

--- a/fluent/client/ws_client.go
+++ b/fluent/client/ws_client.go
@@ -140,7 +140,7 @@ func (c *WSClient) Connect() error {
 		return err
 	}
 
-	connection, err := ws.NewConnection(conn, &c.ConnectionOptions)
+	connection, err := ws.NewConnection(conn, c.ConnectionOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implements the closing handshake as specified by the [websocket spec](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1). The goal is to guarantee that data in transit is handled by both peers and that no data is sent to a closed connection. The basic flow is:

1. `A` sends close message
2. `B` responds with close message
3. `B` closes network connection
4. `A` closes network connection

I also made some changes to simplify error handling in the read handler, though I think it needs a couple more iterations to get right.