### PR TITLE
Add debug logger to ws client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 vendor/
 # Local History for Visual Studio Code
 .history/
+test.message*

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -22,12 +22,6 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
-type DebugOptions struct {
-	// DefaultLogPrefix defines an optional prefix for the default debug logger.
-	DefaultLogPrefix string
-	Logger           Logger
-}
-
 type ReadHandler func(conn Connection, messageType int, p []byte, err error) error
 
 type ConnectionOptions struct {

--- a/fluent/client/ws/connection.go
+++ b/fluent/client/ws/connection.go
@@ -211,7 +211,6 @@ func (wsc *connection) CloseWithMsg(closeCode int, msg string) error {
 	// messages, wait N seconds for a response.
 	if err == nil && wsc.hasConnState(ConnStateListening) &&
 		!wsc.hasConnState(ConnStateCloseReceived) {
-
 		wsc.logger.Println("awaiting peer response")
 
 		select {


### PR DESCRIPTION
Add some simple debug logging to the websocket client. Test output:

```
client> 19:27:46.606280 connection_test.go:52: ReadHandler received error: websocket: close 1000 (normal): closing connection
client> 19:27:46.606300 connection.go:343: handler returned error:  websocket: close 1000 (normal): closing connection
server> 19:27:46.606324 connection_test.go:52: ReadHandler received error: websocket: close 1000 (normal): closing connection
server> 19:27:46.606327 connection.go:343: handler returned error:  websocket: close 1000 (normal): closing connection
server> 19:27:46.607245 connection.go:290: listening
```