### PR TITLE
Change log record type to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fluent-forward-go
 
-`fluent-forward-go` is a fast, memory-efficient implementation of the [Fluent Forward protocol v1](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1). It allows you to send events to [Fluentd](https://www.fluentd.org/), [Fluent Bit](https://fluentbit.io/), and other endpoints supporting the Fluent protocol. It also includes a websocket client for high-speed proxying of Fluent events over ports such as `80` and `443`.
+`fluent-forward-go` is a fast, memory-efficient implementation of the [Fluent Forward v1 specification](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1). It allows you to send events to [Fluentd](https://www.fluentd.org/), [Fluent Bit](https://fluentbit.io/), and other endpoints supporting the Fluent protocol. It also includes a websocket client for high-speed proxying of Fluent events over ports such as `80` and `443`.
 
 Features include:
 
@@ -36,6 +36,8 @@ defer c.Disconnect()
 
 ### Send a new log message
 
+The `record` object must be a `map` or `struct`. Objects that implement the [`msgp.Encodable`](https://pkg.go.dev/github.com/tinylib/msgp/msgp#Encodable) interface will the be most performant.
+
 ```go
 record := map[string]interface{}{
   "first": "Sir",
@@ -51,8 +53,6 @@ if err := c.SendMessage(msg); err != nil {
 ```
 
 ### Send a byte-encoded message
-
-`fluent-forward-go` also supports `ack` for byte-encoded messages so long as the `chunk` option was set before encoding.
 
 ```go
 raw := protocol.RawMessage(myMessageBytes)

--- a/fluent/client/client_test.go
+++ b/fluent/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math/rand"
 	"net"
+	"reflect"
 	"time"
 
 	. "github.com/IBM/fluent-forward-go/fluent/client"
@@ -119,8 +120,7 @@ var _ = Describe("Client", func() {
 			Expect(recvd.Tag).To(Equal(msg.Tag))
 			Expect(recvd.Options).To(Equal(msg.Options))
 			Expect(recvd.Timestamp.Equal(msg.Timestamp.Time)).To(BeTrue())
-			Expect(recvd.Record["first"]).To(Equal(msg.Record["first"]))
-			Expect(recvd.Record["last"]).To(Equal(msg.Record["last"]))
+			Expect(reflect.DeepEqual(recvd.Record, msg.Record)).To(BeTrue())
 		})
 
 		Context("When the Session is not yet in Transport phase (handshake not performed)", func() {

--- a/fluent/protocol/message_gen.go
+++ b/fluent/protocol/message_gen.go
@@ -23,7 +23,7 @@ func (z *Message) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	err = z.Record.EncodeMsg(en)
+	err = en.WriteIntf(z.Record)
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return
@@ -50,7 +50,7 @@ func (z *Message) MarshalMsg(b []byte) (o []byte, err error) {
 	o = append(o, 0x94)
 	o = msgp.AppendString(o, z.Tag)
 	o = msgp.AppendInt64(o, z.Timestamp)
-	o, err = z.Record.MarshalMsg(o)
+	o, err = msgp.AppendIntf(o, z.Record)
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return
@@ -84,7 +84,7 @@ func (z *MessageExt) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	err = z.Record.EncodeMsg(en)
+	err = en.WriteIntf(z.Record)
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return
@@ -115,7 +115,7 @@ func (z *MessageExt) MarshalMsg(b []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	o, err = z.Record.MarshalMsg(o)
+	o, err = msgp.AppendIntf(o, z.Record)
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return

--- a/fluent/protocol/transport.go
+++ b/fluent/protocol/transport.go
@@ -104,7 +104,9 @@ type Record map[string]interface{}
 type EntryExt struct {
 	// Timestamp can contain the timestamp in either seconds or nanoseconds
 	Timestamp EventTime `msg:"eventTime,extension"`
-	// Record is the actual event record - key-value pairs, keys are strings.
+	// Record is the actual event record. The object must be a map or
+	// struct. Objects that implement the msgp.Encodable interface will
+	// be the most performant.
 	Record interface{}
 }
 

--- a/fluent/protocol/transport.go
+++ b/fluent/protocol/transport.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/binary"
 	"errors"
+	"reflect"
 	"sync"
 	"time"
 
@@ -104,7 +105,7 @@ type EntryExt struct {
 	// Timestamp can contain the timestamp in either seconds or nanoseconds
 	Timestamp EventTime `msg:"eventTime,extension"`
 	// Record is the actual event record - key-value pairs, keys are strings.
-	Record Record
+	Record interface{}
 }
 
 type EntryList []EntryExt
@@ -130,20 +131,8 @@ func (e EntryList) Equal(e2 EntryList) bool {
 		for _, eb := range second {
 			if ea.Timestamp.Equal(eb.Timestamp.Time) {
 				// Timestamps equal, check the record
-				if len(ea.Record) == len(eb.Record) {
-					// This only works if we have the same number of kv pairs in each record
-					for k, v := range ea.Record {
-						if eb.Record[k] == v {
-							// KV match, so delete key from each record
-							delete(ea.Record, k)
-							delete(eb.Record, k)
-						}
-					}
-
-					if len(ea.Record) == 0 && len(eb.Record) == 0 {
-						// No more keys left means everything matched
-						matches++
-					}
+				if reflect.DeepEqual(ea.Record, eb.Record) {
+					matches++
 				}
 			}
 		}

--- a/fluent/protocol/transport_gen.go
+++ b/fluent/protocol/transport_gen.go
@@ -287,40 +287,16 @@ func (z *EntryExt) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	var zb0002 uint32
-	zb0002, err = dc.ReadMapHeader()
+	z.Record, err = dc.ReadIntf()
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return
-	}
-	if z.Record == nil {
-		z.Record = make(Record, zb0002)
-	} else if len(z.Record) > 0 {
-		for key := range z.Record {
-			delete(z.Record, key)
-		}
-	}
-	for zb0002 > 0 {
-		zb0002--
-		var za0001 string
-		var za0002 interface{}
-		za0001, err = dc.ReadString()
-		if err != nil {
-			err = msgp.WrapError(err, "Record")
-			return
-		}
-		za0002, err = dc.ReadIntf()
-		if err != nil {
-			err = msgp.WrapError(err, "Record", za0001)
-			return
-		}
-		z.Record[za0001] = za0002
 	}
 	return
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z *EntryExt) EncodeMsg(en *msgp.Writer) (err error) {
+func (z EntryExt) EncodeMsg(en *msgp.Writer) (err error) {
 	// array header, size 2
 	err = en.Append(0x92)
 	if err != nil {
@@ -331,28 +307,16 @@ func (z *EntryExt) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	err = en.WriteMapHeader(uint32(len(z.Record)))
+	err = en.WriteIntf(z.Record)
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return
-	}
-	for za0001, za0002 := range z.Record {
-		err = en.WriteString(za0001)
-		if err != nil {
-			err = msgp.WrapError(err, "Record")
-			return
-		}
-		err = en.WriteIntf(za0002)
-		if err != nil {
-			err = msgp.WrapError(err, "Record", za0001)
-			return
-		}
 	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *EntryExt) MarshalMsg(b []byte) (o []byte, err error) {
+func (z EntryExt) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// array header, size 2
 	o = append(o, 0x92)
@@ -361,14 +325,10 @@ func (z *EntryExt) MarshalMsg(b []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	o = msgp.AppendMapHeader(o, uint32(len(z.Record)))
-	for za0001, za0002 := range z.Record {
-		o = msgp.AppendString(o, za0001)
-		o, err = msgp.AppendIntf(o, za0002)
-		if err != nil {
-			err = msgp.WrapError(err, "Record", za0001)
-			return
-		}
+	o, err = msgp.AppendIntf(o, z.Record)
+	if err != nil {
+		err = msgp.WrapError(err, "Record")
+		return
 	}
 	return
 }
@@ -390,73 +350,43 @@ func (z *EntryExt) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "Timestamp")
 		return
 	}
-	var zb0002 uint32
-	zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	z.Record, bts, err = msgp.ReadIntfBytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err, "Record")
 		return
-	}
-	if z.Record == nil {
-		z.Record = make(Record, zb0002)
-	} else if len(z.Record) > 0 {
-		for key := range z.Record {
-			delete(z.Record, key)
-		}
-	}
-	for zb0002 > 0 {
-		var za0001 string
-		var za0002 interface{}
-		zb0002--
-		za0001, bts, err = msgp.ReadStringBytes(bts)
-		if err != nil {
-			err = msgp.WrapError(err, "Record")
-			return
-		}
-		za0002, bts, err = msgp.ReadIntfBytes(bts)
-		if err != nil {
-			err = msgp.WrapError(err, "Record", za0001)
-			return
-		}
-		z.Record[za0001] = za0002
 	}
 	o = bts
 	return
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *EntryExt) Msgsize() (s int) {
-	s = 1 + msgp.ExtensionPrefixSize + z.Timestamp.Len() + msgp.MapHeaderSize
-	if z.Record != nil {
-		for za0001, za0002 := range z.Record {
-			_ = za0002
-			s += msgp.StringPrefixSize + len(za0001) + msgp.GuessSize(za0002)
-		}
-	}
+func (z EntryExt) Msgsize() (s int) {
+	s = 1 + msgp.ExtensionPrefixSize + z.Timestamp.Len() + msgp.GuessSize(z.Record)
 	return
 }
 
 // DecodeMsg implements msgp.Decodable
 func (z *EntryList) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zb0004 uint32
-	zb0004, err = dc.ReadArrayHeader()
+	var zb0002 uint32
+	zb0002, err = dc.ReadArrayHeader()
 	if err != nil {
 		err = msgp.WrapError(err)
 		return
 	}
-	if cap((*z)) >= int(zb0004) {
-		(*z) = (*z)[:zb0004]
+	if cap((*z)) >= int(zb0002) {
+		(*z) = (*z)[:zb0002]
 	} else {
-		(*z) = make(EntryList, zb0004)
+		(*z) = make(EntryList, zb0002)
 	}
 	for zb0001 := range *z {
-		var zb0005 uint32
-		zb0005, err = dc.ReadArrayHeader()
+		var zb0003 uint32
+		zb0003, err = dc.ReadArrayHeader()
 		if err != nil {
 			err = msgp.WrapError(err, zb0001)
 			return
 		}
-		if zb0005 != 2 {
-			err = msgp.ArrayError{Wanted: 2, Got: zb0005}
+		if zb0003 != 2 {
+			err = msgp.ArrayError{Wanted: 2, Got: zb0003}
 			return
 		}
 		err = dc.ReadExtension(&(*z)[zb0001].Timestamp)
@@ -464,34 +394,10 @@ func (z *EntryList) DecodeMsg(dc *msgp.Reader) (err error) {
 			err = msgp.WrapError(err, zb0001, "Timestamp")
 			return
 		}
-		var zb0006 uint32
-		zb0006, err = dc.ReadMapHeader()
+		(*z)[zb0001].Record, err = dc.ReadIntf()
 		if err != nil {
 			err = msgp.WrapError(err, zb0001, "Record")
 			return
-		}
-		if (*z)[zb0001].Record == nil {
-			(*z)[zb0001].Record = make(Record, zb0006)
-		} else if len((*z)[zb0001].Record) > 0 {
-			for key := range (*z)[zb0001].Record {
-				delete((*z)[zb0001].Record, key)
-			}
-		}
-		for zb0006 > 0 {
-			zb0006--
-			var zb0002 string
-			var zb0003 interface{}
-			zb0002, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, zb0001, "Record")
-				return
-			}
-			zb0003, err = dc.ReadIntf()
-			if err != nil {
-				err = msgp.WrapError(err, zb0001, "Record", zb0002)
-				return
-			}
-			(*z)[zb0001].Record[zb0002] = zb0003
 		}
 	}
 	return
@@ -504,33 +410,21 @@ func (z EntryList) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	for zb0007 := range z {
+	for zb0004 := range z {
 		// array header, size 2
 		err = en.Append(0x92)
 		if err != nil {
 			return
 		}
-		err = en.WriteExtension(&z[zb0007].Timestamp)
+		err = en.WriteExtension(&z[zb0004].Timestamp)
 		if err != nil {
-			err = msgp.WrapError(err, zb0007, "Timestamp")
+			err = msgp.WrapError(err, zb0004, "Timestamp")
 			return
 		}
-		err = en.WriteMapHeader(uint32(len(z[zb0007].Record)))
+		err = en.WriteIntf(z[zb0004].Record)
 		if err != nil {
-			err = msgp.WrapError(err, zb0007, "Record")
+			err = msgp.WrapError(err, zb0004, "Record")
 			return
-		}
-		for zb0008, zb0009 := range z[zb0007].Record {
-			err = en.WriteString(zb0008)
-			if err != nil {
-				err = msgp.WrapError(err, zb0007, "Record")
-				return
-			}
-			err = en.WriteIntf(zb0009)
-			if err != nil {
-				err = msgp.WrapError(err, zb0007, "Record", zb0008)
-				return
-			}
 		}
 	}
 	return
@@ -540,22 +434,18 @@ func (z EntryList) EncodeMsg(en *msgp.Writer) (err error) {
 func (z EntryList) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for zb0007 := range z {
+	for zb0004 := range z {
 		// array header, size 2
 		o = append(o, 0x92)
-		o, err = msgp.AppendExtension(o, &z[zb0007].Timestamp)
+		o, err = msgp.AppendExtension(o, &z[zb0004].Timestamp)
 		if err != nil {
-			err = msgp.WrapError(err, zb0007, "Timestamp")
+			err = msgp.WrapError(err, zb0004, "Timestamp")
 			return
 		}
-		o = msgp.AppendMapHeader(o, uint32(len(z[zb0007].Record)))
-		for zb0008, zb0009 := range z[zb0007].Record {
-			o = msgp.AppendString(o, zb0008)
-			o, err = msgp.AppendIntf(o, zb0009)
-			if err != nil {
-				err = msgp.WrapError(err, zb0007, "Record", zb0008)
-				return
-			}
+		o, err = msgp.AppendIntf(o, z[zb0004].Record)
+		if err != nil {
+			err = msgp.WrapError(err, zb0004, "Record")
+			return
 		}
 	}
 	return
@@ -563,26 +453,26 @@ func (z EntryList) MarshalMsg(b []byte) (o []byte, err error) {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *EntryList) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var zb0004 uint32
-	zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var zb0002 uint32
+	zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err)
 		return
 	}
-	if cap((*z)) >= int(zb0004) {
-		(*z) = (*z)[:zb0004]
+	if cap((*z)) >= int(zb0002) {
+		(*z) = (*z)[:zb0002]
 	} else {
-		(*z) = make(EntryList, zb0004)
+		(*z) = make(EntryList, zb0002)
 	}
 	for zb0001 := range *z {
-		var zb0005 uint32
-		zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		var zb0003 uint32
+		zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err, zb0001)
 			return
 		}
-		if zb0005 != 2 {
-			err = msgp.ArrayError{Wanted: 2, Got: zb0005}
+		if zb0003 != 2 {
+			err = msgp.ArrayError{Wanted: 2, Got: zb0003}
 			return
 		}
 		bts, err = msgp.ReadExtensionBytes(bts, &(*z)[zb0001].Timestamp)
@@ -590,34 +480,10 @@ func (z *EntryList) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err, zb0001, "Timestamp")
 			return
 		}
-		var zb0006 uint32
-		zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+		(*z)[zb0001].Record, bts, err = msgp.ReadIntfBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err, zb0001, "Record")
 			return
-		}
-		if (*z)[zb0001].Record == nil {
-			(*z)[zb0001].Record = make(Record, zb0006)
-		} else if len((*z)[zb0001].Record) > 0 {
-			for key := range (*z)[zb0001].Record {
-				delete((*z)[zb0001].Record, key)
-			}
-		}
-		for zb0006 > 0 {
-			var zb0002 string
-			var zb0003 interface{}
-			zb0006--
-			zb0002, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, zb0001, "Record")
-				return
-			}
-			zb0003, bts, err = msgp.ReadIntfBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, zb0001, "Record", zb0002)
-				return
-			}
-			(*z)[zb0001].Record[zb0002] = zb0003
 		}
 	}
 	o = bts
@@ -627,14 +493,8 @@ func (z *EntryList) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z EntryList) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for zb0007 := range z {
-		s += 1 + msgp.ExtensionPrefixSize + z[zb0007].Timestamp.Len() + msgp.MapHeaderSize
-		if z[zb0007].Record != nil {
-			for zb0008, zb0009 := range z[zb0007].Record {
-				_ = zb0009
-				s += msgp.StringPrefixSize + len(zb0008) + msgp.GuessSize(zb0009)
-			}
-		}
+	for zb0004 := range z {
+		s += 1 + msgp.ExtensionPrefixSize + z[zb0004].Timestamp.Len() + msgp.GuessSize(z[zb0004].Record)
 	}
 	return
 }


### PR DESCRIPTION
This will allow users to pass objects that implement msgp.Encodable, which will be faster. Also, should ease adoption.