### PR TITLE
fix unhandled error from ingester

### DIFF
--- a/fluent/client/ws_client.go
+++ b/fluent/client/ws_client.go
@@ -118,7 +118,7 @@ func (wcf *DefaultWSConnectionFactory) New() (ext.Conn, error) {
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		if readErr == nil {
 			bodyString := string(bodyBytes)
-			if resp.StatusCode == 403 {
+			if resp.StatusCode >= 300 {
 				err = fmt.Errorf("%s. %s:%s", err, strconv.Itoa(resp.StatusCode), bodyString)
 			}
 		}

--- a/fluent/client/ws_client_test.go
+++ b/fluent/client/ws_client_test.go
@@ -66,7 +66,7 @@ var _ = Describe("DefaultWSConnectionFactory", func() {
 		useTLS, testError bool
 	)
 
-	happyHandler := func(happy chan struct{}) http.Handler {
+	happyHandler := func(ch chan struct{}) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer GinkgoRecover()
 			svrOpts := ws.ConnectionOptions{}
@@ -82,13 +82,13 @@ var _ = Describe("DefaultWSConnectionFactory", func() {
 				Fail("broke")
 			}
 
-			happy <- struct{}{}
+			ch <- struct{}{}
 
 			svrConnection.Close()
 		})
 	}
 
-	sadHandler := func(happy chan struct{}) http.Handler {
+	sadHandler := func(ch chan struct{}) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "broken test", http.StatusInternalServerError)
 		})

--- a/fluent/client/ws_client_test.go
+++ b/fluent/client/ws_client_test.go
@@ -204,22 +204,6 @@ var _ = Describe("WSClient", func() {
 			})
 		})
 
-		When("the factory returns an error", func() {
-			var (
-				connectionError error
-			)
-
-			JustBeforeEach(func() {
-				connectionError = errors.New("Nope")
-				factory.NewReturns(nil, connectionError)
-			})
-
-			It("Returns an error", func() {
-				err := client.Connect()
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeIdenticalTo(connectionError))
-			})
-		})
 	})
 
 	Describe("Disconnect", func() {


### PR DESCRIPTION
issue https://github.ibm.com/Observability/pfunk-engineering/issues/1142

the output of the error will come something like this
<img width="1728" alt="Screenshot 2023-09-19 at 11 32 27 AM" src="https://github.com/IBM/fluent-forward-go/assets/32607124/34626956-efce-46da-9d61-2f7a99ba1e9f">


```{"level":"error","ts":"2023-09-19T06:01:31.16490732Z","logger":"platform-agent-plugin","caller":"internal/logger-agent-plugin-impl.go:229","msg":"Error occurred while sending the message to the server","error":"websocket: bad handshake. 403:\"customer not registered for logs service with request `logs-router.cloud.ibm.com/bssAccountID=6a1d10334a2e4dd197d4e301e8f87df9,logs-router.cloud.ibm.com/serviceNameHash=9cf089a4c1757b008afc8561cdad9fd22169d9b4d614bc02ab496708`\"\n","stacktrace":"github.ibm.com/Observability/logger-agent-plugin/pkg/plugin/internal.(*PluginContext).Flush\n\t/root/pkg/plugin/internal/logger-agent-plugin-impl.go:229\nmain.FLBPluginFlushCtx\n\t/root/pkg/plugin/logger-agent-plugin.go:114\n_cgoexp_b4841ca14716_FLBPluginFlushCtx\n\t_cgo_gotypes.go:90\nruntime.cgocallbackg1\n\t/usr/local/go/src/runtime/cgocall.go:315\nruntime.cgocallbackg\n\t/usr/local/go/src/runtime/cgocall.go:234\nruntime.cgocallback\n\t/usr/local/go/src/runtime/asm_amd64.s:998"}```

