### PR TITLE
Fix Authorisation Header 

### DIFF
--- a/fluent/client/ws_client.go
+++ b/fluent/client/ws_client.go
@@ -112,7 +112,7 @@ func (wcf *DefaultWSConnectionFactory) New() (ext.Conn, error) {
 	}
 
 	if wcf.AuthInfo != nil && len(wcf.AuthInfo.IAMToken()) > 0 {
-		header.Add(AuthorizationHeader, wcf.AuthInfo.IAMToken())
+		header.Set(AuthorizationHeader, wcf.AuthInfo.IAMToken())
 	}
 
 	if wcf.TLSConfig != nil {


### PR DESCRIPTION
Replace the `.Add` method with `.Set` to ensure the IAM token is overwritten if it already exists. This prevents multiple entries.